### PR TITLE
text-inverse can be used when background is inverse

### DIFF
--- a/docs/components/utilities.md
+++ b/docs/components/utilities.md
@@ -122,6 +122,7 @@ Convey meaning through color with a handful of emphasis utility classes. These m
 <p class="text-info">Maecenas sed diam eget risus varius blandit sit amet non magna.</p>
 <p class="text-warning">Etiam porta sem malesuada magna mollis euismod.</p>
 <p class="text-danger">Donec ullamcorper nulla non metus auctor fringilla.</p>
+<p class="bg-inverse text-inverse">Curabitur blandit tempus porttitor.</p>
 {% endexample %}
 
 Similar to the contextual text color classes, easily set the background of an element to any contextual class. Anchor components will darken on hover, just like the text classes.

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -110,6 +110,8 @@
 
 @include text-emphasis-variant('.text-danger', $brand-danger);
 
+@include text-emphasis-variant('.text-danger', $body-bg);
+
 
 // Contextual backgrounds
 // For now we'll leave these alongside the text classes until v4 when we can


### PR DESCRIPTION
In situations where the background or background image has inverse color scheme, text-inverse can be used to display text in the original body background color.

Solution for feature request https://github.com/twbs/bootstrap/issues/17634